### PR TITLE
ci: standardize runs-on to ebpro-org

### DIFF
--- a/.github/workflows/ci-qemu.yml
+++ b/.github/workflows/ci-qemu.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
     with:
         # Runner label / machine pool used by the reusable workflow
-        runs-on: arc-runner-set-compute-lsis
+        runs-on: ebpro-org
         # Keep existing env-list usage (stringified list). The reusable workflow
         # may parse this and set environment variables for the job.
         env-list: >


### PR DESCRIPTION
Converts selected self-hosted, empty, and legacy `arc-runner-set-compute-lsis` runner selections to `runs-on: ebpro-org`.

Changes:
- `.github/workflows/ci-qemu.yml` line 18: `        runs-on: arc-runner-set-compute-lsis` -> `        runs-on: ebpro-org`