### PR TITLE
fix(ci): .gitmodules for _quarto-utils, Node24 action bumps, amd64-only publish default

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -32,12 +32,12 @@ jobs:
     runs-on: ebpro-org
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -94,14 +94,14 @@ jobs:
           done < profiles-built.txt
 
       - name: Upload built profiles list
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: profiles-built
           path: profiles-built.txt
 
       - name: Upload SBOMs and scans
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom-and-scans
           path: |

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ebpro-org
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -10,6 +10,10 @@ on:
         description: 'Comma-separated profiles to publish (defaults to all generated)'
         required: false
         default: ''
+      platforms:
+        description: 'Comma-separated target platforms (default linux/amd64 for dev speed; v* tags publish multi-arch)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -22,8 +26,11 @@ env:
 jobs:
   publish:
     # In-cluster ARC runner (actions-runner-controller) with a privileged
-    # docker:dind sidecar; multi-arch via QEMU + docker-container driver.
+    # docker:dind sidecar; multi-arch via QEMU + docker-container driver
+    # only when arm64 is requested (v* tags).
     runs-on: ebpro-org
+    env:
+      PLATFORMS: ${{ github.event.inputs.platforms || (startsWith(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -61,9 +68,11 @@ jobs:
           }
 
       - name: Register QEMU emulators for multi-arch
+        if: contains(env.PLATFORMS, 'arm64')
         run: docker run --rm --privileged tonistiigi/binfmt:latest --install
 
       - name: Create multi-arch buildx builder
+        if: contains(env.PLATFORMS, 'arm64')
         run: docker buildx create --name multiarch --driver docker-container --use
 
       - name: Generate profiles, Dockerfile and bake file
@@ -79,7 +88,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push (linux/amd64 + linux/arm64)
+      - name: Build and push (${{ env.PLATFORMS }})
         env:
           PROFILE_LIST: ${{ github.event.inputs.profiles || '' }}
         run: |
@@ -96,5 +105,5 @@ jobs:
             profile=$(echo "$profile" | xargs)
             echo "Publishing profile: $profile"
             docker buildx bake --file generated/docker-bake.hcl "final-$profile" \
-              --set '*.platform=linux/amd64,linux/arm64' --push
+              --set "*.platform=${PLATFORMS}" --push
           done

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
       IMAGE_NAME: ${{ github.event.repository.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -100,7 +100,7 @@ jobs:
           done < digests.csv
 
       - name: Upload digests artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: promoted-digests
           path: digests.csv

--- a/.github/workflows/validate-artefacts.yml
+++ b/.github/workflows/validate-artefacts.yml
@@ -17,7 +17,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Run artefacts validator

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "samples/quarto-lecture-containers/_quarto-utils"]
+	path = samples/quarto-lecture-containers/_quarto-utils
+	url = https://github.com/ebpro/_quarto-utils.git


### PR DESCRIPTION
Fixes ci-publish failure: gitlink samples/quarto-lecture-containers/_quarto-utils had no .gitmodules (checkout post-step exit 128). Bumps checkout/setup-python/upload-artifact to Node24 majors. Publish now targets linux/amd64 by default (dispatch input 'platforms' to override; v* tags stay multi-arch).