### PR TITLE
fix(ci): publish image as ghcr.io/ebpro/jupyter-base

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Generate Dockerfile and bake file
         run: |
           solen generate dockerfile --all --output generated/Dockerfile
-          solen generate bake --output generated/docker-bake.hcl
+          solen generate bake --output generated/docker-bake.hcl --repo "$IMAGE_REPO" --image-name "$IMAGE_NAME"
 
       - name: Build profiles (single-arch, loaded into local daemon)
         id: build

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           solen generate profiles --matrix profiles/matrix --out generated/profiles --chain
           solen generate dockerfile --all --output generated/Dockerfile
-          solen generate bake --output generated/docker-bake.hcl
+          solen generate bake --output generated/docker-bake.hcl --repo "$IMAGE_REPO" --image-name "$IMAGE_NAME"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/solen-cli/solen/cli.py
+++ b/solen-cli/solen/cli.py
@@ -304,15 +304,17 @@ def devcontainer(ctx: click.Context, profile: str | None, all_profiles: bool, ou
 @generate.command()
 @click.option('--output', type=click.Path(path_type=Path),
               default=Path('generated/docker-bake.hcl'), help='Output path')
+@click.option('--repo', default='ghcr.io/ebpro', help='Container registry/org URL')
+@click.option('--image-name', default='jupyter-base', help='Container image name')
 @click.pass_context
-def bake(ctx: click.Context, output: Path) -> None:
+def bake(ctx: click.Context, output: Path, repo: str, image_name: str) -> None:
     """Generate docker-bake.hcl for all profiles."""
     from solen.generators.bake import generate_bake
 
     repo_root = ctx.obj['repo_root']
     output_path = repo_root / output if not output.is_absolute() else output
 
-    count = generate_bake(repo_root, output_path)
+    count = generate_bake(repo_root, output_path, repo=repo, image_name=image_name)
     click.echo(f"✅ Generated docker-bake.hcl with {count} profile(s): {output_path}")
 
 


### PR DESCRIPTION
GITHUB_TOKEN (packages: write) cannot push to the pre-existing private 'solen' GHCR package (permission_denied: write_package). Name the image after the repo instead: 'generate bake' gains --repo/--image-name (defaults ghcr.io/ebpro/jupyter-base) and both build workflows pass the existing IMAGE_REPO/IMAGE_NAME envs.